### PR TITLE
#2 Enforce GUID usage over character names for comms

### DIFF
--- a/src/comms.lua
+++ b/src/comms.lua
@@ -77,7 +77,7 @@ function SilentRotate:sendSyncTranq(hunter, fail, timestamp)
         ['type'] = SilentRotate.constants.commsTypes.tranqshotDone,
         ['mode'] = SilentRotate.db.profile.currentMode,
         ['timestamp'] = timestamp,
-        ['player'] = hunter.name,
+        ['player'] = hunter.GUID,
         ['fail'] = fail,
     }
 

--- a/src/rotation.lua
+++ b/src/rotation.lua
@@ -466,7 +466,7 @@ function SilentRotate:getSimpleRotationTables()
 
     for key, rotationTable in pairs(SilentRotate.rotationTables) do
         for _, hunter in pairs(rotationTable) do
-            table.insert(simpleTables[key], hunter.name)
+            table.insert(simpleTables[key], hunter.GUID)
         end
     end
 


### PR DESCRIPTION
This second step (merge #17 first) fix the broken comms on ERA connected realms, and should not affect player that use a version of the addon with the first step on a single realm