### PR TITLE
FearWard TBC

### DIFF
--- a/src/modes.lua
+++ b/src/modes.lua
@@ -110,7 +110,11 @@ function SilentRotate:getModeDuration(mode)
     elseif SilentRotate:isDistractMode() then
         duration = 30 -- Cooldown of Rogue's Distract
     elseif SilentRotate:isFearWardMode() then
-        duration = 30
+        if WOW_PROJECT_ID == WOW_PROJECT_CLASSIC then
+            duration = 30
+        else
+            duration = 180
+        end
     elseif SilentRotate:isAoeTauntMode() then
         duration = 600 -- Cooldown of Warrior's Challenging Shout and Druid's Challenging Roar
     else

--- a/src/modes.lua
+++ b/src/modes.lua
@@ -90,7 +90,7 @@ function SilentRotate:isPlayerWanted(unit, className, mode)
     elseif SilentRotate:isDistractMode(mode) then
         return className == 'ROGUE'
     elseif SilentRotate:isFearWardMode(mode) then
-        return className == 'PRIEST' and (select(2,UnitRace(unit)) == 'Dwarf' or WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC)
+        return className == 'PRIEST' and (select(2,UnitRace(unit)) == 'Dwarf' or WOW_PROJECT_ID ~= WOW_PROJECT_CLASSIC)
     elseif SilentRotate:isAoeTauntMode(mode) then
         return className == 'WARRIOR' or className == 'DRUID'
     end

--- a/src/modes.lua
+++ b/src/modes.lua
@@ -90,7 +90,7 @@ function SilentRotate:isPlayerWanted(unit, className, mode)
     elseif SilentRotate:isDistractMode(mode) then
         return className == 'ROGUE'
     elseif SilentRotate:isFearWardMode(mode) then
-        return className == 'PRIEST' and select(2,UnitRace(unit)) == 'Dwarf'
+        return className == 'PRIEST' and (select(2,UnitRace(unit)) == 'Dwarf' or WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC)
     elseif SilentRotate:isAoeTauntMode(mode) then
         return className == 'WARRIOR' or className == 'DRUID'
     end


### PR DESCRIPTION
The Burning Crusade Classic gave the Fear Ward spell to all priests, but at the cost of increasing the cooldown to 3 minutes (up from 30 seconds) and reducing the buff duration to 3 minutes (down from 10 minutes).

SilentRotate now detects which WoW project is currently used (Era Classic or TBC Classic) and adjusts the FearWard mode accordingly.